### PR TITLE
ImageMagick: add patch to hardcode thresholds

### DIFF
--- a/Formula/imagemagick-static.rb
+++ b/Formula/imagemagick-static.rb
@@ -4,9 +4,9 @@ class ImagemagickStatic < Formula
   # Please always keep the Homebrew mirror as the primary URL as the
   # ImageMagick site removes tarballs regularly which means we get issues
   # unnecessarily and older versions of the formula are broken.
-  url "https://dl.bintray.com/homebrew/mirror/imagemagick%406-6.9.11-57.tar.xz"
-  mirror "https://www.imagemagick.org/download/releases/ImageMagick-6.9.11-57.tar.xz"
-  sha256 "1a1d35a6e702a498d34b4a4f9fbf5aab228ee233d18b83f742163071fc6b7e05"
+  url "https://dl.bintray.com/homebrew/mirror/ImageMagick-6.9.12-3.tar.xz"
+  mirror "https://www.imagemagick.org/download/releases/ImageMagick-6.9.12-3.tar.xz"
+  sha256 "b9bf05a49f878713d96bc9c88d21414adaf2a542125530e2dee8a07128ef8ed1"
   license "ImageMagick"
   head "https://github.com/imagemagick/imagemagick6.git"
 
@@ -20,6 +20,11 @@ class ImagemagickStatic < Formula
     sha256 arm64_big_sur: "52489f1fef59e8fc8a02334bceac3f7ad243d9d6a3f8c3d6925874e683332e88"
     sha256 big_sur:       "2655e14531075144149aefe6e9cfdda99ed0df9179677af8b4134015e3572f58"
     sha256 catalina:      "0d41ab3c54f9dd8764e7f7b0b8fc2ab1c5eccda0b20700591e7034c691aea7e6"
+  end
+
+  # Hardcode thresholds.xml
+  patch do
+    url "https://patch-diff.githubusercontent.com/raw/ImageMagick/ImageMagick6/pull/141.diff"
   end
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
@dawidd6 I copied [your CI scripts](https://github.com/dawidd6/homebrew-tap/tree/master/.github/workflows), but somehow things started failing on big-sur with this error. Do you have any guess what the problem is?

```
==> Running Formulae#detect_formulae!
==> git -C /usr/local/Homebrew/Library/Taps/autobrew/homebrew-cran fetch origin +refs/heads/master
    url             https://github.com/autobrew/homebrew-cran/pull/21/checks
    origin/master   61db2a1 (Run brew style --fix)
    HEAD            c647ee5 (Merge be31ac35c0b3751082470837da7ee43ae995da96 into 61db2a1eb60124a0d7cce972f535daf380dd97ad)
    diff_start_sha1 61db2a1eb60124a0d7cce972f535daf380dd97ad
    diff_end_sha1   c647ee5a47944b3e10d50e5f97ab9f09c85d4515
==> Testing Formula changes:
    added    (empty)
    modified autobrew/cran/imagemagick-static
    deleted  (empty)
Error: Failed to determine dependencies for 'autobrew/cran/imagemagick-static'.
Error: Process completed with exit code 1.
```

Strangely, this only fails on 11.0 and not 10.15, with exactly the same version of homebrew. Perhaps the version of ruby is the culprit 🤔 